### PR TITLE
Enable CORS pre-flighting

### DIFF
--- a/surrogethd/js/app.js
+++ b/surrogethd/js/app.js
@@ -31,6 +31,7 @@ const nonceKey = `nonce_${relayerAccount.address}`;
 
 const app = express();
 app.use(cors());
+app.options("*", cors());
 app.use(express.json());
 
 app.get("/address", (req, res) => {


### PR DESCRIPTION
The error I got was:

```
Access to XMLHttpRequest at 'http://<IP ADDRESS>/submit_tx' from origin 'http://localhost' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

The fix is from this guide:

https://github.com/expressjs/cors#enabling-cors-pre-flight