### PR TITLE
Another CORS fix, a tweak to SURROGETH_MIN_TX_PROFIT, and a bugfix

### DIFF
--- a/surrogethd/js/app.js
+++ b/surrogethd/js/app.js
@@ -82,8 +82,12 @@ app.post(
         .json({ msg: `I don't send transactions to ${to}` });
     }
 
+    // simulate the transaction
     const profit = await simulateTx(network, to, data, value);
-    if (profit <= SURROGETH_MIN_TX_PROFIT) {
+
+    // only check whether the profit is sufficient if SURROGETH_MIN_TX_PROFIT
+    // is set to a positive value
+    if (SURROGETH_MIN_TX_PROFIT > 0 && profit <= SURROGETH_MIN_TX_PROFIT) {
       return res.status(403).json({
         msg: `Fee too low! Try increasing the fee by ${SURROGETH_MIN_TX_PROFIT -
           profit} Wei`

--- a/surrogethd/js/app.js
+++ b/surrogethd/js/app.js
@@ -30,8 +30,19 @@ const lock = new AsyncLock();
 const nonceKey = `nonce_${relayerAccount.address}`;
 
 const app = express();
+
+// enable CORS
 app.use(cors());
 app.options("*", cors());
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Origin, X-Requested-With, Content-Type, Accept"
+  );
+  next();
+});
+
 app.use(express.json());
 
 app.get("/address", (req, res) => {

--- a/surrogethd/js/eth/engines.js
+++ b/surrogethd/js/eth/engines.js
@@ -10,7 +10,9 @@ const {
   KOVAN_RPC_URL,
   MAINNET_RPC_URL,
   LOCAL_RPC_URL,
-  SURROGETH_PRIVATE_KEY
+  SURROGETH_PRIVATE_KEY,
+  KOVAN_ALLOWED_RECIPIENTS,
+  MAINNET_ALLOWED_RECIPIENTS
 } = require("../config");
 
 const networkToRpcUrl = network => {


### PR DESCRIPTION
1. The Express middleware to add access control headers should fix the CORS issue for good (I've tested it on my server)
2. There was a bug where the Kovan and mainnet allowed recipients weren't imported from config
3. It's now possible to override profit-checking by setting `SURROGETH_MIN_TX_PROFIT` to `-1`