### PR TITLE
Adds Heroku support and makes the surrogethd port configurable

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: cd surrogethd && npm run start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: cd surrogethd && npm run start
+web: npm run start --prefix surrogethd

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "surrogeth",
+  "version": "0.0.1",
+  "scripts": {
+    "postinstall": "npm install --prefix surrogethd"
+  }
+}

--- a/surrogethd/js/config.js
+++ b/surrogethd/js/config.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 
 const envVars = [
+  "PORT",
   "KOVAN_RPC_URL",
   "MAINNET_RPC_URL",
   "LOCAL_RPC_URL",

--- a/surrogethd/js/server.js
+++ b/surrogethd/js/server.js
@@ -1,8 +1,10 @@
+const { PORT } = require("./config");
 const app = require("./app");
 
 // Configure console logging statements
 require("console-stamp")(console);
 
-app.listen(8080, () => {
-  console.info("surrogethd listening on port 8080");
+const port = PORT || 8080;
+app.listen(port, () => {
+  console.info("surrogethd listening on port " + port);
 });


### PR DESCRIPTION
Heroku is a simple way to get HTTPS for free if you want to run `surrogethd`. This PR includes a `Procfile` and `package.json` which tells Heroku to use the Nodejs buildpack to install dependencies and launch the server.

I also made the server port configurable. This lets anyone set the `PORT` config variable to `80`. The Heroku docs state:

> The command in a web process type must bind to the port number specified in the PORT environment variable. If it does not, the dyno will not start.

Before making the server port configurable, I tried setting `PORT` to the default value (`8080`) but it didn't work. Nevertheless, this could be a helpful feature.